### PR TITLE
WIP Setting up recording feature

### DIFF
--- a/include/audio_render_stage/audio_effect_render_stage.h
+++ b/include/audio_render_stage/audio_effect_render_stage.h
@@ -43,7 +43,7 @@ public:
     ~AudioEchoEffectRenderStage() {};
 
 private:
-    void render(unsigned int time) override;
+    void render(const unsigned int time) override;
 
     std::vector<float> m_echo_buffer;
 };

--- a/include/audio_render_stage/audio_effect_render_stage.h
+++ b/include/audio_render_stage/audio_effect_render_stage.h
@@ -46,6 +46,8 @@ private:
     void render(const unsigned int time) override;
 
     std::vector<float> m_echo_buffer;
+
+    static const unsigned int M_MAX_ECHO_BUFFER_SIZE = 200;
 };
 
 #endif // AUDIO_EFFECT_RENDER_STAGE_H

--- a/include/audio_render_stage/audio_effect_render_stage.h
+++ b/include/audio_render_stage/audio_effect_render_stage.h
@@ -2,7 +2,7 @@
 #ifndef AUDIO_EFFECT_RENDER_STAGE_H
 #define AUDIO_EFFECT_RENDER_STAGE_H
 
-#include "audio_render_stage.h"
+#include "audio_render_stage/audio_render_stage.h"
 
 class AudioEffectRenderStage : public AudioRenderStage {
 public:

--- a/include/audio_render_stage/audio_render_stage.h
+++ b/include/audio_render_stage/audio_render_stage.h
@@ -118,7 +118,10 @@ protected:
      * 
      * This function is responsible for rendering the stage and all parameters
      */
-    virtual void render(unsigned int time);
+    virtual void render(const unsigned int time);
+
+    // Time
+    unsigned int m_time = 0;
 
     // Initialized
     bool m_initialized = false;

--- a/include/audio_render_stage/audio_tape_render_stage.h
+++ b/include/audio_render_stage/audio_tape_render_stage.h
@@ -1,0 +1,25 @@
+#pragma once
+#ifndef AUDIO_TAPE_RENDER_STAGE_H
+#define AUDIO_TAPE_RENDER_STAGE_H
+
+#include "audio_render_stage/audio_render_stage.h"
+
+class AudioRecordRenderStage : public AudioRenderStage {
+public:
+    AudioRecordRenderStage(const unsigned int frames_per_buffer,
+                           const unsigned int sample_rate,
+                           const unsigned int num_channels,
+                           const std::string& fragment_shader_path = "build/shaders/record_render_stage.glsl",
+                           const std::vector<std::string> & frag_shader_imports = default_frag_shader_imports);
+
+    static const std::vector<std::string> default_frag_shader_imports;
+
+    ~AudioRecordRenderStage() {};
+
+private:
+    void render(unsigned int time) override;
+
+    std::vector<float> m_tape;
+};
+
+#endif // AUDIO_TAPE_RENDER_STAGE_H

--- a/include/audio_render_stage/audio_tape_render_stage.h
+++ b/include/audio_render_stage/audio_tape_render_stage.h
@@ -4,22 +4,67 @@
 
 #include "audio_render_stage/audio_render_stage.h"
 
+typedef std::vector<float> Tape;
 class AudioRecordRenderStage : public AudioRenderStage {
 public:
     AudioRecordRenderStage(const unsigned int frames_per_buffer,
                            const unsigned int sample_rate,
                            const unsigned int num_channels,
-                           const std::string& fragment_shader_path = "build/shaders/record_render_stage.glsl",
-                           const std::vector<std::string> & frag_shader_imports = default_frag_shader_imports);
+                           const std::string& fragment_shader_path = "build/shaders/render_stage_frag.glsl",
+                           const std::vector<std::string> & frag_shader_imports = default_frag_shader_imports)
+    : AudioRenderStage(frames_per_buffer, sample_rate, num_channels, fragment_shader_path, frag_shader_imports) {}
 
     static const std::vector<std::string> default_frag_shader_imports;
 
     ~AudioRecordRenderStage() {};
 
-private:
-    void render(unsigned int time) override;
+    void record(unsigned int record_position);
+    void stop();
+    bool is_recording() {
+        return m_recording;
+    }
+    Tape & get_tape() {
+        return m_tape;
+    }
 
-    std::vector<float> m_tape;
+private:
+    void render(const unsigned int time) override;
+
+    Tape m_tape;
+
+    bool m_recording = false;
+    unsigned int m_record_position = 0;
+    unsigned int m_record_start_time = 0;
+};
+
+class AudioPlaybackRenderStage : public AudioRenderStage {
+public:
+    AudioPlaybackRenderStage(const unsigned int frames_per_buffer,
+                             const unsigned int sample_rate,
+                             const unsigned int num_channels,
+                             const std::string& fragment_shader_path = "build/shaders/playback_render_stage.glsl",
+                             const std::vector<std::string> & frag_shader_imports = default_frag_shader_imports);
+
+    static const std::vector<std::string> default_frag_shader_imports;
+
+    ~AudioPlaybackRenderStage() {};
+
+    void load_tape(const Tape & tape);
+
+    void play(unsigned int play_position);
+    void stop();
+    bool is_playing();
+
+private:
+    void render(const unsigned int time) override;
+
+    const unsigned int get_current_tape_position(const unsigned int time);
+
+    void load_tape_data_to_texture(const Tape & tape, const unsigned int offset);
+
+    const Tape * m_tape_ptr;
+
+    static const unsigned int M_TAPE_SIZE = 200;
 };
 
 #endif // AUDIO_TAPE_RENDER_STAGE_H

--- a/lib/audio_parameter/audio_texture2d_parameter.cpp
+++ b/lib/audio_parameter/audio_texture2d_parameter.cpp
@@ -97,6 +97,7 @@ bool AudioTexture2DParameter::initialize(GLuint frame_buffer, AudioShaderProgram
         }
     }
 
+    // Using pixel buffer object may be faster, the extra code for that is commented out
     // Unbind the texture
     //glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/lib/audio_render_stage/audio_generator_render_stage.cpp
+++ b/lib/audio_render_stage/audio_generator_render_stage.cpp
@@ -67,7 +67,7 @@ AudioGeneratorRenderStage::AudioGeneratorRenderStage(const unsigned int frames_p
     auto attack_time_parameter =
         new AudioFloatParameter("attack_time",
                               AudioParameter::ConnectionType::INPUT);
-    attack_time_parameter->set_value(0.1f);
+    attack_time_parameter->set_value(0.2f);
 
     auto decay_time_parameter =
         new AudioFloatParameter("decay_time",
@@ -82,7 +82,7 @@ AudioGeneratorRenderStage::AudioGeneratorRenderStage(const unsigned int frames_p
     auto release_time_parameter =
         new AudioFloatParameter("release_time",
                               AudioParameter::ConnectionType::INPUT);
-    release_time_parameter->set_value(0.1f);
+    release_time_parameter->set_value(0.2f);
 
     if (!this->add_parameter(attack_time_parameter)) {
         std::cerr << "Failed to add attack_time_parameter" << std::endl;

--- a/lib/audio_render_stage/audio_render_stage.cpp
+++ b/lib/audio_render_stage/audio_render_stage.cpp
@@ -159,7 +159,9 @@ bool AudioRenderStage::bind() {
     return true;
 }
 
-void AudioRenderStage::render(unsigned int time) {
+void AudioRenderStage::render(const unsigned int time) {
+    m_time = time;
+
     // Use the shader program of the stage
     glUseProgram(m_shader_program->get_program());
 

--- a/lib/audio_render_stage/audio_tape_render_stage.cpp
+++ b/lib/audio_render_stage/audio_tape_render_stage.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <vector>
 
+#include "audio_parameter/audio_texture2d_parameter.h"
 #include "audio_parameter/audio_uniform_parameter.h"
 #include "audio_render_stage/audio_tape_render_stage.h"
 
@@ -9,60 +10,140 @@ const std::vector<std::string> AudioRecordRenderStage::default_frag_shader_impor
     "build/shaders/frag_shader_settings.glsl"
 };
 
-AudioRecordRenderStage::AudioRecordRenderStage(const unsigned int frames_per_buffer,
-                                               const unsigned int sample_rate,
-                                               const unsigned int num_channels,
-                                               const std::string & fragment_shader_path,
-                                               const std::vector<std::string> & frag_shader_imports)
-    : AudioRenderStage(frames_per_buffer, sample_rate, num_channels, fragment_shader_path, frag_shader_imports) {
-
-    auto record_time = 
-        new AudioIntParameter("record_position",
-                              AudioParameter::ConnectionType::INPUT);
-    record_time->set_value(0);
-
-    auto recording = 
-        new AudioBoolParameter("recording",
-                              AudioParameter::ConnectionType::INPUT);
-    recording->set_value(false);
-
-    if (!this->add_parameter(record_time)) {
-        std::cerr << "Failed to add record_time" << std::endl;
-    }
-    if (!this->add_parameter(recording)) {
-        std::cerr << "Failed to add recording" << std::endl;
-    }
-}
-
 void AudioRecordRenderStage::render(unsigned int time) {
-
-    // Copy the audio data to the tape
-    static int prev_time = 0;
 
     auto * data = (float *)this->find_parameter("stream_audio_texture")->get_value();
 
-    unsigned int record_time = *(int *)this->find_parameter("record_position")->get_value();
+    if (m_recording && time != m_time) {
 
-    bool recording = *(bool *)this->find_parameter("recording")->get_value();
-
-    if (recording && time != prev_time) {
-        // FIXME: Current time is not set right
+        unsigned int record_time = time - m_record_start_time + m_record_position;
         // If the tape is smaller than the record time, then resize the tape
         if (m_tape.size() <= record_time * m_frames_per_buffer * m_num_channels) {
             m_tape.resize((record_time + 1) * m_frames_per_buffer * m_num_channels); // Fill with 0s
         }
 
-        printf("Tape size: %d\n", m_tape.size());
-
         // Copy the audio data to the tape
-        std::copy(data, data + m_frames_per_buffer * m_num_channels, m_tape.begin() + record_time);
+        std::copy(data, data + m_frames_per_buffer * m_num_channels, m_tape.begin() + record_time*m_frames_per_buffer*m_num_channels);
     }
 
-    prev_time = time;
-
     AudioRenderStage::render(time);
+}
 
-    //printf("Tape size: %d\n", m_tape.size());
+void AudioRecordRenderStage::record(unsigned int record_position) {
+    m_recording = true;
+    m_record_start_time = m_time;
+    m_record_position = record_position;
+    printf("Recording started at time %d\n", m_record_start_time);
+}
+
+void AudioRecordRenderStage::stop() {
+    m_recording = false;
+    printf("Recording stopped at time %d\n", m_time);
 }
 
 // TODO: Implement copy and paste functionality
+
+// TODO: Set functionality to save this data and reload it on shutdown
+const std::vector<std::string> AudioPlaybackRenderStage::default_frag_shader_imports = {
+    "build/shaders/global_settings.glsl",
+    "build/shaders/frag_shader_settings.glsl"
+};
+
+AudioPlaybackRenderStage::AudioPlaybackRenderStage(const unsigned int frames_per_buffer,
+                                                   const unsigned int sample_rate,
+                                                   const unsigned int num_channels,
+                                                   const std::string& fragment_shader_path,
+                                                   const std::vector<std::string> & frag_shader_imports)
+        : AudioRenderStage(frames_per_buffer, sample_rate, num_channels, fragment_shader_path, frag_shader_imports) {
+
+    auto playback_texture = new AudioTexture2DParameter("playback_texture",
+                                                        AudioParameter::ConnectionType::INPUT,
+                                                        m_frames_per_buffer * m_num_channels, M_TAPE_SIZE, // Store 2 seconds of sound at a time
+                                                        ++m_active_texture_count,
+                                                        0);
+    playback_texture->set_value(new float[m_frames_per_buffer * m_num_channels * M_TAPE_SIZE]);
+
+    auto play_position = new AudioIntParameter("play_position",
+                                               AudioParameter::ConnectionType::INPUT);
+    play_position->set_value(0);
+
+    auto time_at_start = new AudioIntParameter("time_at_start",
+                                               AudioParameter::ConnectionType::INPUT);
+    time_at_start->set_value(0);
+
+    auto play = new AudioBoolParameter("play",
+                                          AudioParameter::ConnectionType::INPUT);
+    play->set_value(false);
+
+
+    if (!this->add_parameter(playback_texture)) {
+        std::cerr << "Failed to add playback_texture" << std::endl;
+    }
+    if (!this->add_parameter(play_position)) {
+        std::cerr << "Failed to add play_position" << std::endl;
+    }
+    if (!this->add_parameter(time_at_start)) {
+        std::cerr << "Failed to add time_at_start" << std::endl;
+    }
+    if (!this->add_parameter(play)) {
+        std::cerr << "Failed to add play" << std::endl;
+    }
+}
+
+void AudioPlaybackRenderStage::load_tape(const Tape & tape) {
+    m_tape_ptr = &tape;
+}
+
+void AudioPlaybackRenderStage::play(unsigned int play_position) {
+    printf("Playing at position %d\n", play_position);
+    this->find_parameter("play_position")->set_value(play_position);
+    this->find_parameter("time_at_start")->set_value(m_time);
+    this->find_parameter("play")->set_value(true);
+}
+
+void AudioPlaybackRenderStage::stop() {
+    printf("Stopping playback\n");
+    this->find_parameter("play")->set_value(false);
+}
+
+bool AudioPlaybackRenderStage::is_playing() {
+    return *(bool *)this->find_parameter("play")->get_value();
+}
+
+const unsigned int AudioPlaybackRenderStage::get_current_tape_position(const unsigned int time) {
+    const unsigned int play_position = *(unsigned int *)this->find_parameter("play_position")->get_value();
+    const unsigned int time_at_start = *(unsigned int *)this->find_parameter("time_at_start")->get_value();
+
+    return (play_position + time - time_at_start) * m_frames_per_buffer * m_num_channels;
+}
+
+void AudioPlaybackRenderStage::load_tape_data_to_texture(const Tape & tape, const unsigned int offset) {
+    // Get the right segment of tape
+    float * data = new float[m_frames_per_buffer * m_num_channels * M_TAPE_SIZE]();
+
+    std::copy(tape.begin() + offset, tape.begin() + offset + m_frames_per_buffer * m_num_channels * M_TAPE_SIZE, data);
+
+    this->find_parameter("playback_texture")->set_value(data);
+}
+
+void AudioPlaybackRenderStage::render(const unsigned int time) {
+    // Only load the data into the playback_texture if 
+        // Play parameter is true
+        // tape is loaded
+        // There is still data left to play
+    auto offset = get_current_tape_position(time);
+    
+    if (is_playing()) {
+        // If there is still audio to play
+        if (m_tape_ptr != nullptr && offset < m_tape_ptr->size()) {
+            // If there's a need to load the tape
+            if (offset % (m_frames_per_buffer * m_num_channels * M_TAPE_SIZE) == 0) {
+                load_tape_data_to_texture(*m_tape_ptr, offset);
+            }
+        } else {
+            stop();
+        }
+    }
+
+    AudioRenderStage::render(time);
+}

--- a/lib/audio_render_stage/audio_tape_render_stage.cpp
+++ b/lib/audio_render_stage/audio_tape_render_stage.cpp
@@ -121,7 +121,12 @@ void AudioPlaybackRenderStage::load_tape_data_to_texture(const Tape & tape, cons
     // Get the right segment of tape
     float * data = new float[m_frames_per_buffer * m_num_channels * M_TAPE_SIZE]();
 
-    std::copy(tape.begin() + offset, tape.begin() + offset + m_frames_per_buffer * m_num_channels * M_TAPE_SIZE, data);
+    // If the tape ends before the offset, then fill with 0s
+    if (offset + m_frames_per_buffer * m_num_channels * M_TAPE_SIZE > tape.size()) {
+        std::copy(tape.begin() + offset, tape.end(), data);
+    } else {
+        std::copy(tape.begin() + offset, tape.begin() + offset + m_frames_per_buffer * m_num_channels * M_TAPE_SIZE, data);
+    }
 
     this->find_parameter("playback_texture")->set_value(data);
 }

--- a/lib/audio_render_stage/audio_tape_render_stage.cpp
+++ b/lib/audio_render_stage/audio_tape_render_stage.cpp
@@ -1,0 +1,68 @@
+#include <iostream>
+#include <vector>
+
+#include "audio_parameter/audio_uniform_parameter.h"
+#include "audio_render_stage/audio_tape_render_stage.h"
+
+const std::vector<std::string> AudioRecordRenderStage::default_frag_shader_imports = {
+    "build/shaders/global_settings.glsl",
+    "build/shaders/frag_shader_settings.glsl"
+};
+
+AudioRecordRenderStage::AudioRecordRenderStage(const unsigned int frames_per_buffer,
+                                               const unsigned int sample_rate,
+                                               const unsigned int num_channels,
+                                               const std::string & fragment_shader_path,
+                                               const std::vector<std::string> & frag_shader_imports)
+    : AudioRenderStage(frames_per_buffer, sample_rate, num_channels, fragment_shader_path, frag_shader_imports) {
+
+    auto record_time = 
+        new AudioIntParameter("record_position",
+                              AudioParameter::ConnectionType::INPUT);
+    record_time->set_value(0);
+
+    auto recording = 
+        new AudioBoolParameter("recording",
+                              AudioParameter::ConnectionType::INPUT);
+    recording->set_value(false);
+
+    if (!this->add_parameter(record_time)) {
+        std::cerr << "Failed to add record_time" << std::endl;
+    }
+    if (!this->add_parameter(recording)) {
+        std::cerr << "Failed to add recording" << std::endl;
+    }
+}
+
+void AudioRecordRenderStage::render(unsigned int time) {
+
+    // Copy the audio data to the tape
+    static int prev_time = 0;
+
+    auto * data = (float *)this->find_parameter("stream_audio_texture")->get_value();
+
+    unsigned int record_time = *(int *)this->find_parameter("record_position")->get_value();
+
+    bool recording = *(bool *)this->find_parameter("recording")->get_value();
+
+    if (recording && time != prev_time) {
+        // FIXME: Current time is not set right
+        // If the tape is smaller than the record time, then resize the tape
+        if (m_tape.size() <= record_time * m_frames_per_buffer * m_num_channels) {
+            m_tape.resize((record_time + 1) * m_frames_per_buffer * m_num_channels); // Fill with 0s
+        }
+
+        printf("Tape size: %d\n", m_tape.size());
+
+        // Copy the audio data to the tape
+        std::copy(data, data + m_frames_per_buffer * m_num_channels, m_tape.begin() + record_time);
+    }
+
+    prev_time = time;
+
+    AudioRenderStage::render(time);
+
+    //printf("Tape size: %d\n", m_tape.size());
+}
+
+// TODO: Implement copy and paste functionality

--- a/lib/keyboard/key.cpp
+++ b/lib/keyboard/key.cpp
@@ -15,7 +15,6 @@ PianoKey::PianoKey(const unsigned char key) : Key(key) {
     //audio_generator = new AudioGeneratorRenderStage(512, 44100, 2, "build/shaders/square_generator_render_stage.glsl");
     audio_generator = new AudioGeneratorRenderStage(512, 44100, 2, "build/shaders/sine_generator_render_stage.glsl");
     //audio_generator = new AudioGeneratorRenderStage(512, 44100, 2, "build/shaders/static_generator_render_stage.glsl");
-    //audio_generator = new AudioFileGeneratorRenderStage(512, 44100, 2, "media/test.wav");
 
     auto gid = audio_generator->gid;
 

--- a/shaders/effect_render_stages/echo_effect_render_stage.glsl
+++ b/shaders/effect_render_stages/echo_effect_render_stage.glsl
@@ -5,7 +5,7 @@ uniform sampler2D echo_audio_texture;
 
 void main() {
     ivec2 echo_buffer_size = ivec2(textureSize(echo_audio_texture, 0));
-    float echo_sample_data_size_in_seconds = float(echo_buffer_size.y) * float(buffer_size) / float(sample_rate);
+    float echo_sample_data_size_in_seconds = (float(echo_buffer_size.y/2) - 0.5) * float(buffer_size) / float(sample_rate);
     float delay_increment = delay / echo_sample_data_size_in_seconds;
 
     vec4 echo = vec4(0.0, 0.0, 0.0, 0.0);

--- a/shaders/io_render_stages/final_render_stage.glsl
+++ b/shaders/io_render_stages/final_render_stage.glsl
@@ -5,6 +5,9 @@ void main() {
     // Map the audio sample to the y-coordinate
     float y = (audioSample + 1.0) / 2.0; // Assuming audioSample is in range [-1, 1]
 
+    // Flip the y-coordinate
+    y = 1.0 - y;
+
     // Draw a line at the y-coordinate
     if (abs(TexCoord.y - y) < 0.003) {
         output_audio_texture = vec4(1.0, 1.0, 1.0, 1.0); // White line

--- a/shaders/tape_render_stages/playback_render_stage.glsl
+++ b/shaders/tape_render_stages/playback_render_stage.glsl
@@ -9,9 +9,9 @@ void main() {
     if (play) {
         ivec2 playback_buffer_size = ivec2(textureSize(playback_texture, 0));
 
-        int offset = (global_time_val - time_at_start + play_position) % playback_buffer_size.y;
+        int offset = (global_time_val - time_at_start + play_position) % (playback_buffer_size.y / 2); // divide by 2 because spacing
 
-        float playback_sample_index =  float(offset) / float(playback_buffer_size.y);
+        float playback_sample_index =  (float(offset * 2) + 0.5) / float(playback_buffer_size.y);
 
         playback = texture(playback_texture, vec2(TexCoord.x, playback_sample_index));
     }

--- a/shaders/tape_render_stages/playback_render_stage.glsl
+++ b/shaders/tape_render_stages/playback_render_stage.glsl
@@ -1,0 +1,20 @@
+uniform sampler2D playback_texture;
+uniform int play_position;
+uniform bool play;
+uniform int time_at_start;
+
+void main() {
+    vec4 playback = vec4(0.0, 0.0, 0.0, 0.0);
+
+    if (play) {
+        ivec2 playback_buffer_size = ivec2(textureSize(playback_texture, 0));
+
+        int offset = (global_time_val - time_at_start + play_position) % playback_buffer_size.y;
+
+        float playback_sample_index =  float(offset) / float(playback_buffer_size.y);
+
+        playback = texture(playback_texture, vec2(TexCoord.x, playback_sample_index));
+    }
+
+    output_audio_texture = texture(stream_audio_texture, TexCoord) + playback;
+}

--- a/shaders/tape_render_stages/record_render_stage.glsl
+++ b/shaders/tape_render_stages/record_render_stage.glsl
@@ -1,6 +1,0 @@
-uniform bool recording;
-uniform int record_position;
-
-void main() {
-    output_audio_texture = texture(stream_audio_texture, TexCoord);
-}

--- a/shaders/tape_render_stages/record_render_stage.glsl
+++ b/shaders/tape_render_stages/record_render_stage.glsl
@@ -1,0 +1,6 @@
+uniform bool recording;
+uniform int record_position;
+
+void main() {
+    output_audio_texture = texture(stream_audio_texture, TexCoord);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,19 +58,37 @@ int main(int argc, char** argv) {
     auto effect_render_stage = new AudioGainEffectRenderStage(512, 44100, 2);
     auto echo_render_stage = new AudioEchoEffectRenderStage(512, 44100, 2);
     auto record_render_stage = new AudioRecordRenderStage(512, 44100, 2);
+    auto playback_render_stage = new AudioPlaybackRenderStage(512, 44100, 2);
     auto final_render_stage = new AudioFinalRenderStage(512, 44100, 2);
 
     keyboard.get_output_render_stage()->connect_render_stage(effect_render_stage);
     effect_render_stage->connect_render_stage(echo_render_stage);
     echo_render_stage->connect_render_stage(record_render_stage);
-    record_render_stage->connect_render_stage(final_render_stage);
+    record_render_stage->connect_render_stage(playback_render_stage);
+    playback_render_stage->connect_render_stage(final_render_stage);
 
-    auto record_param = record_render_stage->find_parameter("recording");
     auto record_key = new Key('r');
-    record_key->set_key_down_callback([&record_param]() {
-        record_param->set_value(!*(bool *)record_param->get_value());
+    record_key->set_key_down_callback([&record_render_stage]() {
+        if (record_render_stage->is_recording()) {
+            record_render_stage->stop();
+        } else {
+            record_render_stage->record(0);
+        }
     });
     keyboard.add_key(record_key);
+
+    auto playback_key = new Key('l');
+    playback_key->set_key_down_callback([&playback_render_stage, &record_render_stage]() {
+        // Load the data
+        playback_render_stage->load_tape(record_render_stage->get_tape());
+
+        if (playback_render_stage->is_playing()) {
+            playback_render_stage->stop();
+        } else {
+            playback_render_stage->play(0);
+        }
+    });
+    keyboard.add_key(playback_key);
 
     auto audio_render_graph = new AudioRenderGraph(final_render_stage);
 
@@ -99,7 +117,6 @@ int main(int argc, char** argv) {
     gain_param->set_value(1.0f);
     auto balance_param = effect_render_stage->find_parameter("balance");
     balance_param->set_value(0.5f);
-
 
     // Start the audio renderer main loop
     audio_renderer.start_main_loop();

--- a/tests/audio_playback_test.cpp
+++ b/tests/audio_playback_test.cpp
@@ -1,0 +1,116 @@
+#include "catch2/catch_all.hpp"
+#include <thread>
+#include <iostream>
+#include <mutex>
+
+#include "audio_core/audio_renderer.h"
+#include "audio_render_stage/audio_tape_render_stage.h"
+#include "audio_render_stage/audio_final_render_stage.h"
+#include "audio_core/audio_render_graph.h"
+#include "audio_output/audio_player_output.h"
+
+TEST_CASE("AudioPlaybackRenderStage_test_empty_tape") {
+    auto audio_playback_render_stage = new AudioPlaybackRenderStage(512, 44100, 2);
+    auto audio_final_render_stage = new AudioFinalRenderStage(512, 44100, 2);
+
+    audio_playback_render_stage->connect_render_stage(audio_final_render_stage);
+
+    auto audio_render_graph = new AudioRenderGraph({audio_final_render_stage});
+
+    auto audio_driver = new AudioPlayerOutput(512, 44100, 2);
+
+    AudioRenderer & audio_renderer = AudioRenderer::get_instance();
+
+    audio_playback_render_stage->load_tape({});
+
+    audio_renderer.add_render_graph(audio_render_graph);
+    audio_renderer.add_render_output(audio_driver);
+
+    // Open a thread to wait few sec and the shut it down
+    std::thread t1([&audio_renderer, &audio_playback_render_stage](){
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        audio_playback_render_stage->play(0);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        audio_renderer.terminate();
+    });
+
+    REQUIRE(audio_renderer.initialize(512, 44100, 2));
+
+    REQUIRE(audio_driver->open());
+    REQUIRE(audio_driver->start());
+
+    audio_renderer.start_main_loop();
+
+    t1.detach();
+}
+
+TEST_CASE("AudioPlaybackRenderStage_test_small_tape") {
+    auto audio_playback_render_stage = new AudioPlaybackRenderStage(512, 44100, 2);
+    auto audio_final_render_stage = new AudioFinalRenderStage(512, 44100, 2);
+
+    audio_playback_render_stage->connect_render_stage(audio_final_render_stage);
+
+    auto audio_render_graph = new AudioRenderGraph({audio_final_render_stage});
+
+    auto audio_driver = new AudioPlayerOutput(512, 44100, 2);
+
+    AudioRenderer & audio_renderer = AudioRenderer::get_instance();
+
+    audio_playback_render_stage->load_tape({0.0f, 1.0f, 0.0f, 1.0f});
+
+    audio_renderer.add_render_graph(audio_render_graph);
+    audio_renderer.add_render_output(audio_driver);
+
+    // Open a thread to wait few sec and the shut it down
+    std::thread t1([&audio_renderer, &audio_playback_render_stage](){
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        audio_playback_render_stage->play(1);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        audio_renderer.terminate();
+    });
+
+    REQUIRE(audio_renderer.initialize(512, 44100, 2));
+
+    REQUIRE(audio_driver->open());
+    REQUIRE(audio_driver->start());
+
+    audio_renderer.start_main_loop();
+
+    t1.detach();
+}
+
+TEST_CASE("AudioPlaybackRenderStage_test_large_tape") {
+    auto audio_playback_render_stage = new AudioPlaybackRenderStage(512, 44100, 2);
+    auto audio_final_render_stage = new AudioFinalRenderStage(512, 44100, 2);
+
+    audio_playback_render_stage->connect_render_stage(audio_final_render_stage);
+
+    auto audio_render_graph = new AudioRenderGraph({audio_final_render_stage});
+
+    auto audio_driver = new AudioPlayerOutput(512, 44100, 2);
+
+    AudioRenderer & audio_renderer = AudioRenderer::get_instance();
+
+    auto tape = std::vector<float>(44100 * 5 + 12, 1.0f);
+    audio_playback_render_stage->load_tape(tape);
+
+    audio_renderer.add_render_graph(audio_render_graph);
+    audio_renderer.add_render_output(audio_driver);
+
+    // Open a thread to wait few sec and the shut it down
+    std::thread t1([&audio_renderer, &audio_playback_render_stage](){
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        audio_playback_render_stage->play(2);
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+        audio_renderer.terminate();
+    });
+
+    REQUIRE(audio_renderer.initialize(512, 44100, 2));
+
+    REQUIRE(audio_driver->open());
+    REQUIRE(audio_driver->start());
+
+    audio_renderer.start_main_loop();
+
+    t1.detach();
+}


### PR DESCRIPTION
audio library should have render stage that can save the sound in a channel in a vector at a command.
- [x] Figure out how to create a render stage that outputs to a pixel buffer
- [x] That same render stage should be able to save the audio data in a floating point vector
- [x] Should be able to start recording and end recording at different parts, should be able to manipulate the recording
- [x] Add render stage to play back the audio that is recorded
- [x] Add unit tests
- [x] Fix negative feedback issue