### PR TITLE
Fixed popping sound and seg fault

### DIFF
--- a/lib/audio_render_stage/audio_effect_render_stage.cpp
+++ b/lib/audio_render_stage/audio_effect_render_stage.cpp
@@ -52,7 +52,7 @@ AudioEchoEffectRenderStage::AudioEchoEffectRenderStage(const unsigned int frames
     auto feedback_parameter =
         new AudioIntParameter("num_echos",
                                 AudioParameter::ConnectionType::INPUT);
-    feedback_parameter->set_value(5);
+    feedback_parameter->set_value(0);
 
     auto delay_parameter =
         new AudioFloatParameter("delay",

--- a/lib/audio_render_stage/audio_generator_render_stage.cpp
+++ b/lib/audio_render_stage/audio_generator_render_stage.cpp
@@ -67,22 +67,22 @@ AudioGeneratorRenderStage::AudioGeneratorRenderStage(const unsigned int frames_p
     auto attack_time_parameter =
         new AudioFloatParameter("attack_time",
                               AudioParameter::ConnectionType::INPUT);
-    attack_time_parameter->set_value(0.2f);
+    attack_time_parameter->set_value(1.0f);
 
     auto decay_time_parameter =
         new AudioFloatParameter("decay_time",
                               AudioParameter::ConnectionType::INPUT);
-    decay_time_parameter->set_value(0.0f);
+    decay_time_parameter->set_value(1.0f);
 
     auto sustain_level_parameter =
         new AudioFloatParameter("sustain_level",
                               AudioParameter::ConnectionType::INPUT);
-    sustain_level_parameter->set_value(1.0f);
+    sustain_level_parameter->set_value(0.2f);
 
     auto release_time_parameter =
         new AudioFloatParameter("release_time",
                               AudioParameter::ConnectionType::INPUT);
-    release_time_parameter->set_value(0.2f);
+    release_time_parameter->set_value(0.1f);
 
     if (!this->add_parameter(attack_time_parameter)) {
         std::cerr << "Failed to add attack_time_parameter" << std::endl;

--- a/lib/audio_render_stage/audio_tape_render_stage.cpp
+++ b/lib/audio_render_stage/audio_tape_render_stage.cpp
@@ -123,6 +123,11 @@ const unsigned int AudioPlaybackRenderStage::get_current_tape_position(const uns
 }
 
 void AudioPlaybackRenderStage::load_tape_data_to_texture(const Tape & tape, const unsigned int offset) {
+    // If there is no data in the tape, then return
+    if (tape.size() == 0) {
+        return;
+    }
+
     // Get the right segment of tape
     float * buffered_data = new float[m_frames_per_buffer * m_num_channels * M_TAPE_SIZE]();
 


### PR DESCRIPTION
Fix issue of popping sound when playing a key repeatedly rapidly.

Likely caused by constructive interference with periodic waves, replicate by pausing the audio and playing the sound multiple times, and then incrementing

- [x] Change adsr envelope to start the decay where attack leaves off when playing sound
- [x] (kind of unrelated) Fix playback to not seg fault when no data is recorded